### PR TITLE
Add permalink: false to experience.json for CV positions

### DIFF
--- a/src/cv/experience/experience.json
+++ b/src/cv/experience/experience.json
@@ -1,4 +1,5 @@
 {
+  "permalink": false,
   "tags": [
     "cvExperience"
   ]


### PR DESCRIPTION
Was ouputting permalinks for each CV position in the `dist` folder. This removes that.

see: https://www.11ty.dev/docs/permalinks/#permalink-false