### PR TITLE
Use custom collection for blog posts + setup collection-specific tags

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -22,6 +22,10 @@ module.exports = function (eleventyConfig) {
     excerpt_separator: "<!-- excerpt -->",
   });
 
+  eleventyConfig.addCollection("blog", function (collectionApi) {
+    return collectionApi.getFilteredByGlob("src/blog/*.md");
+  });
+
   return {
     dir: {
       input: "src",

--- a/src/blog/hello.md
+++ b/src/blog/hello.md
@@ -1,6 +1,6 @@
 ---
 title: Punchy Blog Title That's Extremely Long
-tags: ["blog", "markdown", "slug this tag", "typography"]
+tags: ["markdown", "slug this tag", "typography"]
 ---
 
 Torem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam sagittis metus nec elit consectetur, non rhoncus augue hendrerit. Donec ac volutpat lectus, sed molestie magna. Mauris ac rhoncus ex. Nam aliquet sem tristique scelerisque ultrices. Proin hendrerit at enim eu congue. Vestibulum imperdiet risus non laoreet sodales. Suspendisse sodales eros vel nunc vulputate elementum. Sed viverra nisi vitae nibh pulvinar vehicula. Nam ac posuere nibh, eu malesuada enim.

--- a/src/blog/post2.md
+++ b/src/blog/post2.md
@@ -1,6 +1,6 @@
 ---
 title: "My second blog post"
-tags: ["blog", "content", "where am i"]
+tags: ["content", "where am i"]
 ---
 
 Hi all, sorry I've not blogged in a while. This new post will be the start of lots of new blogging. Check out my blog!

--- a/src/blog/thirdPost.md
+++ b/src/blog/thirdPost.md
@@ -1,6 +1,6 @@
 ---
 title: "Keeping The Blog Dream Alive"
-tags: ["blog", "content", "padding"]
+tags: ["content", "padding"]
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis suscipit porttitor pellentesque. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Aenean nec venenatis velit, sit amet egestas ante. Nunc commodo tortor a leo malesuada elementum. Maecenas a felis ullamcorper, fermentum ex consectetur, convallis nisl. Integer faucibus risus eu justo hendrerit, quis pharetra neque vehicula. Phasellus pellentesque in ex ac eleifend. Nullam ullamcorper tempor arcu non suscipit. Vestibulum imperdiet non lacus ac pharetra. Pellentesque sit amet rutrum magna. Praesent iaculis, quam at blandit suscipit, dui nulla hendrerit justo, eu tempus lectus ante et ipsum. Integer euismod, lectus vel pulvinar sollicitudin, purus magna accumsan justo, at ultrices justo arcu vel nunc. Donec mattis varius volutpat. Pellentesque malesuada viverra lacinia. Aliquam consectetur est nulla, vitae semper ex finibus non. Sed in risus quis tellus mattis fermentum.

--- a/src/pages/tag.11ty.js
+++ b/src/pages/tag.11ty.js
@@ -7,10 +7,10 @@ const { Title } = require("../components/Title");
 exports.data = {
   layout: "base",
   pagination: {
-    data: "collections",
+    data: "collections.blog",
     size: 1,
     alias: "tag",
-    filter: ["blog", "nav", "all"],
+    before: getUniqueTagsFromCollection,
   },
   permalink: function (data) {
     return `blog/tags/${this.slug(data.tag)}/`;
@@ -19,6 +19,18 @@ exports.data = {
     title: ({ tag }) => capitalise(tag),
   },
 };
+
+function getUniqueTagsFromCollection(data) {
+  const uniqueTags = new Set();
+
+  for (let template of data) {
+    for (let tag of template.data.tags) {
+      uniqueTags.add(tag);
+    }
+  }
+
+  return [...uniqueTags];
+}
 
 function capitalise(string) {
   return string


### PR DESCRIPTION
This initially looks like more work than is needed, but it sets the foundation for being able to have collection-specific groups of tags, as opposed to one overall set of tags for the entire site.

And I haven't figured out an easier way to do that, yet 😄  